### PR TITLE
Simplify types

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -37,7 +37,7 @@ describe("useAsyncQuery", () => {
       const onError = jest.fn();
       beforeEach(() => {
         renderHookResult = renderHook(
-          (options) => useAsyncQuery(mockQuery, options),
+          (options) => useAsyncQuery<string, string>(mockQuery, options),
           {
             initialProps: { variables: "run1", onCompleted, onError },
           }
@@ -223,7 +223,7 @@ describe("useAsyncQuery", () => {
     describe("is called without variables", () => {
       let renderHookResult: RenderHookResult<never, Result<string>>;
       beforeEach(() => {
-        renderHookResult = renderHook(() => useAsyncQuery(mockQuery));
+        renderHookResult = renderHook(() => useAsyncQuery<string, never>(mockQuery));
       });
       it("should start with loading set to true", async () => {
         expect(mockQuery).toHaveBeenCalledWith();

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,13 @@
 import { useState, useRef, useMemo } from "react";
 
-interface OptionsWithVariables<TData, TVariables> extends Options<TData> {
-  variables: TVariables;
+type Variables = Record<string, any>;
+
+interface Options<TData, TVariables> {
+  variables?: TVariables;
   skip?: boolean;
   onCompleted?: (data: TData) => void;
   onError?: (error: any) => void;
 }
-type Options<TData> = {
-  skip?: boolean;
-  onCompleted?: (data: TData) => void;
-  onError?: (error: any) => void;
-};
 
 export type Result<TData> = {
   loading: boolean;
@@ -24,17 +21,9 @@ export type Result<TData> = {
  * [Apollo's useQuery hook](https://www.apollographql.com/docs/react/data/queries/#usequery-api),
  * but with a "query" being any async function rather than GQL statement.
  */
-function useAsyncQuery<TData>(
-  query: () => Promise<TData>,
-  options?: Options<TData>
-): Result<TData>;
-function useAsyncQuery<TData, TVariables>(
-  query: (variables: TVariables) => Promise<TData>,
-  options: OptionsWithVariables<TData, TVariables>
-): Result<TData>;
-function useAsyncQuery<TData, TVariables>(
+function useAsyncQuery<TData = any, TVariables = Variables>(
   query: (variables?: TVariables) => Promise<TData>,
-  options?: OptionsWithVariables<TData, TVariables> | Options<TData>
+  options?: Options<TData, TVariables>
 ): Result<TData> {
   const { skip, onCompleted, onError } = options || {};
 


### PR DESCRIPTION
Apollo's types aren't overloaded for variables, so won't attempt to do here