### PR TITLE
Typed mocks, Reinstate overloads

### DIFF
--- a/use-lazy-query.test.ts
+++ b/use-lazy-query.test.ts
@@ -21,7 +21,7 @@ class Deferred<T> {
 describe("useLazyQuery", () => {
   describe("when an asyncronous query", () => {
     let deferred: Deferred<string>;
-    const mockQuery = jest.fn();
+    const mockQuery = jest.fn<Promise<string>, [string]>();
 
     beforeEach(() => {
       deferred = new Deferred<string>();

--- a/use-lazy-query.ts
+++ b/use-lazy-query.ts
@@ -1,9 +1,16 @@
 import { useCallback, useState } from "react";
 
-import { useQuery, QueryOptions, QueryResult } from "./use-query";
+import {
+  useQuery,
+  QueryOptions,
+  QueryResult,
+  QueryOptionsWithVariables,
+} from "./use-query";
 
-export type LazyQueryOptions<TData, TVariables> = Omit<
-  QueryOptions<TData, TVariables>,
+export type LazyQueryOptions<TData> = Omit<QueryOptions<TData>, "skip">;
+
+export type LazyQueryOptionsWithVariables<TData, TVariables> = Omit<
+  QueryOptionsWithVariables<TData, TVariables>,
   "skip"
 >;
 
@@ -18,9 +25,19 @@ export type LazyQueryResult<TData, TVariables> = [
   QueryResult<TData, TVariables> & { called?: boolean }
 ];
 
-export function useLazyQuery<TData = any, TVariables = Record<string, any>>(
+export function useLazyQuery<TData>(
+  query: () => Promise<TData>,
+  options?: LazyQueryOptions<TData>
+): LazyQueryResult<TData, never>;
+export function useLazyQuery<TData, TVariables>(
+  query: (variables: TVariables) => Promise<TData>,
+  options: LazyQueryOptionsWithVariables<TData, TVariables>
+): LazyQueryResult<TData, TVariables>;
+export function useLazyQuery<TData, TVariables>(
   query: (variables?: TVariables) => Promise<TData>,
-  options?: LazyQueryOptions<TData, TVariables>
+  options?:
+    | LazyQueryOptionsWithVariables<TData, TVariables>
+    | LazyQueryOptions<TData>
 ): LazyQueryResult<TData, TVariables> {
   const [execution, setExecution] = useState<{
     called: boolean;

--- a/use-query.test.ts
+++ b/use-query.test.ts
@@ -19,9 +19,9 @@ class Deferred<T> {
 }
 
 describe("useQuery", () => {
-  describe("when an asyncronous query", () => {
+  describe("when an asyncronous query with variables", () => {
     let deferred: Deferred<string>;
-    const mockQuery = jest.fn();
+    const mockQuery = jest.fn<Promise<string>, [string]>();
 
     beforeEach(() => {
       deferred = new Deferred<string>();
@@ -31,10 +31,10 @@ describe("useQuery", () => {
       mockQuery.mockReset();
     });
 
-    describe("is called with variables", () => {
+    describe("is called", () => {
       let renderHookResult: RenderHookResult<any, QueryResult<string, string>>;
-      const onCompleted = jest.fn();
-      const onError = jest.fn();
+      const onCompleted = jest.fn<void, [string]>();
+      const onError = jest.fn<void, [any]>();
       beforeEach(() => {
         renderHookResult = renderHook(
           (options) => useQuery<string, string>(mockQuery, options),
@@ -223,26 +223,11 @@ describe("useQuery", () => {
       });
     });
 
-    describe("is called without variables", () => {
-      let renderHookResult: RenderHookResult<never, QueryResult<string, never>>;
-      beforeEach(() => {
-        renderHookResult = renderHook(() => useQuery<string, never>(mockQuery));
-      });
-      it("should start with loading set to true", async () => {
-        expect(mockQuery).toHaveBeenCalled();
-        expect(mockQuery).toHaveBeenCalledTimes(1);
-        expect(renderHookResult.result.current.error).toBe(null);
-        expect(renderHookResult.result.current.loading).toBe(true);
-        expect(renderHookResult.result.current.data).toBe(null);
-        expect(renderHookResult.result.all.length).toBe(1);
-      });
-    });
-
     describe("is called with skip set to true", () => {
       let renderHookResult: RenderHookResult<any, QueryResult<string, string>>;
       beforeEach(() => {
         renderHookResult = renderHook(
-          (options) => useQuery(mockQuery, options),
+          (options) => useQuery<string, string>(mockQuery, options),
           { initialProps: { skip: true } }
         );
       });
@@ -310,6 +295,34 @@ describe("useQuery", () => {
             expect(renderHookResult.result.all.length).toBe(3);
           });
         });
+      });
+    });
+  });
+
+  describe("when an asyncronous query without variables", () => {
+    let deferred: Deferred<string>;
+    const mockQuery = jest.fn<Promise<string>, never>();
+
+    beforeEach(() => {
+      deferred = new Deferred<string>();
+      mockQuery.mockReturnValue(deferred.promise);
+    });
+    afterEach(() => {
+      mockQuery.mockReset();
+    });
+
+    describe("is called without variables", () => {
+      let renderHookResult: RenderHookResult<never, QueryResult<string, never>>;
+      beforeEach(() => {
+        renderHookResult = renderHook(() => useQuery<string>(mockQuery));
+      });
+      it("should start with loading set to true", async () => {
+        expect(mockQuery).toHaveBeenCalled();
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        expect(renderHookResult.result.current.error).toBe(null);
+        expect(renderHookResult.result.current.loading).toBe(true);
+        expect(renderHookResult.result.current.data).toBe(null);
+        expect(renderHookResult.result.all.length).toBe(1);
       });
     });
   });

--- a/use-query.ts
+++ b/use-query.ts
@@ -2,7 +2,13 @@ import { useState, useRef, useMemo, useCallback } from "react";
 
 type Variables = Record<string, any>;
 
-export interface QueryOptions<TData, TVariables> {
+export interface QueryOptions<TData> {
+  skip?: boolean;
+  onCompleted?: (data: TData) => void;
+  onError?: (error: any) => void;
+}
+
+export interface QueryOptionsWithVariables<TData, TVariables> {
   variables?: TVariables;
   skip?: boolean;
   onCompleted?: (data: TData) => void;
@@ -24,9 +30,17 @@ export type QueryResult<TData, TVariables = Variables> = {
  * [Apollo's useQuery hook](https://www.apollographql.com/docs/react/data/queries/#usequery-api),
  * but with a "query" being any async function rather than GQL statement.
  */
-function useQuery<TData = any, TVariables = Variables>(
+function useQuery<TData>(
+  query: () => Promise<TData>,
+  options?: QueryOptions<TData>
+): QueryResult<TData, never>;
+function useQuery<TData, TVariables>(
+  query: (variables: TVariables) => Promise<TData>,
+  options: QueryOptionsWithVariables<TData, TVariables>
+): QueryResult<TData, TVariables>;
+function useQuery<TData, TVariables>(
   query: (variables?: TVariables) => Promise<TData>,
-  options?: QueryOptions<TData, TVariables>
+  options?: QueryOptionsWithVariables<TData, TVariables> | QueryOptions<TData>
 ): QueryResult<TData, TVariables> {
   const { skip, onCompleted, onError } = options || {};
 


### PR DESCRIPTION
1. Apply types to Jest mocks. Jest mocks were previously typed to accept and return `any`, so appropriate type errors were not being thrown
2. Reinstate overloads to resolve type issues