### PR TITLE
Don't call side effects in useMemo

### DIFF
--- a/use-query.ts
+++ b/use-query.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { equal } from "@wry/equality";
 
 export type Variables = Record<string, any>;
@@ -117,9 +117,9 @@ function useQuery<TData, TVariables extends Variables>(
     [query, variables, onCompleted, onError]
   );
 
-  useMemo(async () => {
+  useEffect(() => {
     if (!skip) {
-      await fetch();
+      fetch();
     }
   }, [fetch, skip]);
 


### PR DESCRIPTION
Fixes some strict mode issues during development due to double invoking useMemo

https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects

> Remember that the function passed to useMemo runs during rendering. Don’t do anything there that you wouldn’t normally do while rendering. For example, side effects belong in useEffect, not useMemo.

https://reactjs.org/docs/hooks-reference.html#usememo

Fixes #47 

Massive thanks to @dai-shi for explaining a few details helping with the final piece of the puzzle (dealing with double invocation of useEffect with a ref)

https://discord.com/channels/627656437971288081/905738792164556800/977210103847596043