### PR TITLE
Refetch refetch tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "eslint": "^8.13.0",
         "eslint-config-react-app": "^7.0.0",
         "jest": "^27.5.1",
-        "react": "^18.1.0",
-        "react-test-renderer": "^17.0.2",
+        "react": "^18.2.0",
+        "react-test-renderer": "^18.2.0",
         "ts-jest": "^27.1.3",
         "tsd": "^0.19.1",
         "typescript": "^4.5.5"
@@ -7345,9 +7345,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -7400,19 +7400,24 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
       "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -7738,13 +7743,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -14197,9 +14201,9 @@
       "dev": true
     },
     "react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
@@ -14245,15 +14249,22 @@
       }
     },
     "react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -14496,13 +14507,12 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "eslint": "^8.13.0",
     "eslint-config-react-app": "^7.0.0",
     "jest": "^27.5.1",
-    "react": "^18.1.0",
-    "react-test-renderer": "^17.0.2",
+    "react": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
     "ts-jest": "^27.1.3",
     "tsd": "^0.19.1",
     "typescript": "^4.5.5"

--- a/use-lazy-query.test.ts
+++ b/use-lazy-query.test.ts
@@ -21,7 +21,7 @@ class Deferred<T> {
 }
 
 describe("useLazyQuery", () => {
-  describe("when an asyncronous query with variables", () => {
+  describe("is given an asyncronous query with variables", () => {
     let deferred: Deferred<string>;
     const mockQuery = jest.fn<Promise<string>, [{ option: string }]>();
     afterEach(() => {
@@ -32,7 +32,7 @@ describe("useLazyQuery", () => {
       mockQuery.mockReturnValue(deferred.promise);
     });
 
-    describe("is called with variables", () => {
+    describe("the hook is rendered with variables", () => {
       let renderHookResult: RenderHookResult<
         LazyQueryResult<string, { option: string }>,
         LazyQueryOptionsWithVariables<string, { option: string }>
@@ -191,7 +191,7 @@ describe("useLazyQuery", () => {
         });
       });
     });
-    describe("is called without options or variables", () => {
+    describe("the hook is rendered without options or variables", () => {
       let renderHookResult: RenderHookResult<
         LazyQueryResultVariablesRequiredInRefetch<string, { option: string }>,
         LazyQueryOptionsWithVariables<string, { option: string }>
@@ -200,8 +200,7 @@ describe("useLazyQuery", () => {
         renderHookResult = renderHook<
           LazyQueryResultVariablesRequiredInRefetch<string, { option: string }>,
           LazyQueryOptionsWithVariables<string, { option: string }>
-        >(() => useLazyQuery<string, { option: string }>(mockQuery), {
-        });
+        >(() => useLazyQuery<string, { option: string }>(mockQuery), {});
       });
       it("should start with loading set to false", async () => {
         expect(mockQuery).toHaveBeenCalledTimes(0);
@@ -210,7 +209,7 @@ describe("useLazyQuery", () => {
         expect(renderHookResult.result.current[1].data).toBe(null);
       });
     });
-    describe("is called with options but no variables", () => {
+    describe("the hook is rendered with options but no variables", () => {
       let renderHookResult: RenderHookResult<
         LazyQueryResultVariablesRequiredInRefetch<string, { option: string }>,
         LazyQueryOptionsWithVariables<string, { option: string }>

--- a/use-query.test.ts
+++ b/use-query.test.ts
@@ -20,8 +20,8 @@ class Deferred<T> {
   }
 }
 
-describe("useQuery", () => {
-  describe("when an asyncronous query with variables", () => {
+describe("when useQuery", () => {
+  describe("is given an asyncronous query with variables", () => {
     type QueryVariables = { optionA: string; optionB: string };
     type QueryResponse = string;
     let deferred: Deferred<QueryResponse>;
@@ -35,7 +35,7 @@ describe("useQuery", () => {
       mockQuery.mockReturnValue(deferred.promise);
     });
 
-    describe("is called", () => {
+    describe("the hook is rendered", () => {
       let renderHookResult: RenderHookResult<
         QueryResult<QueryResponse, QueryVariables>,
         QueryOptionsWithVariables<QueryResponse, QueryVariables>
@@ -126,7 +126,7 @@ describe("useQuery", () => {
           });
         });
 
-        describe("the hook is called again with the same props", () => {
+        describe("the hook is rerendered with the same props", () => {
           beforeEach(async () => {
             await act(async () => {
               renderHookResult.rerender({
@@ -150,7 +150,7 @@ describe("useQuery", () => {
           });
         });
 
-        describe("is called with different variables", () => {
+        describe("the hook is rerendered with different variables", () => {
           let deferred2: Deferred<string>;
           beforeEach(() => {
             deferred2 = new Deferred<string>();
@@ -212,7 +212,7 @@ describe("useQuery", () => {
         });
       });
 
-      describe("is called with different variables", () => {
+      describe("the hook is rerendered with different variables", () => {
         let deferred2: Deferred<string>;
         beforeEach(() => {
           deferred2 = new Deferred<string>();
@@ -306,7 +306,7 @@ describe("useQuery", () => {
       });
     });
 
-    describe("is called with skip set to true", () => {
+    describe("the hook is rendered with skip set to true", () => {
       let renderHookResult: RenderHookResult<
         QueryResult<QueryResponse, QueryVariables>,
         QueryOptionsWithVariables<QueryResponse, QueryVariables>
@@ -332,7 +332,7 @@ describe("useQuery", () => {
         expect(renderHookResult.result.current.loading).toBe(false);
         expect(renderHookResult.result.current.data).toBe(null);
       });
-      describe("is called again with skip not set", () => {
+      describe("the hook is rerendered with skip not set", () => {
         beforeEach(() => {
           renderHookResult.rerender({
             variables: { optionA: "run2-A", optionB: "run2-B" },
@@ -368,7 +368,7 @@ describe("useQuery", () => {
             renderHookResult.result.current.refetch({ optionB: "run2-B" });
           });
         });
-        it("should call the query with merged variabls", () => {
+        it("should call the query with merged variables", () => {
           expect(mockQuery).toHaveBeenCalledWith({
             optionA: "run1-A",
             optionB: "run2-B",
@@ -397,7 +397,7 @@ describe("useQuery", () => {
     });
   });
 
-  describe("when an asyncronous query without variables", () => {
+  describe("is given an asyncronous query without variables", () => {
     let deferred: Deferred<string>;
     const mockQuery = jest.fn<Promise<string>, never>();
     afterEach(() => {
@@ -409,7 +409,7 @@ describe("useQuery", () => {
       mockQuery.mockReturnValue(deferred.promise);
     });
 
-    describe("is called without variables", () => {
+    describe("the hook is rendered without variables", () => {
       let renderHookResult: RenderHookResult<
         QueryResult<string, never>,
         QueryOptions<string>
@@ -444,7 +444,7 @@ describe("useQuery", () => {
       mockQuery.mockReturnValue(deferred.promise);
     });
 
-    describe("is called in React.StrictMode", () => {
+    describe("the hook is rendered in React.StrictMode", () => {
       let renderHookResult: RenderHookResult<
         QueryResult<QueryResponse, QueryVariables>,
         QueryOptionsWithVariables<QueryResponse, QueryVariables>
@@ -484,7 +484,7 @@ describe("useQuery", () => {
           expect(onCompleted).toHaveBeenCalledWith("resolved");
         });
 
-        describe("the hook is called again with the same props", () => {
+        describe("the hook is rerendered with the same props", () => {
           beforeEach(async () => {
             await act(async () => {
               renderHookResult.rerender({
@@ -499,7 +499,7 @@ describe("useQuery", () => {
           });
         });
 
-        describe("is called with different variables", () => {
+        describe("the hook is rerendered with different variables", () => {
           let deferred2: Deferred<string>;
           beforeEach(() => {
             deferred2 = new Deferred<string>();
@@ -539,7 +539,7 @@ describe("useQuery", () => {
         });
       });
 
-      describe("is called with different variables", () => {
+      describe("the hook is rerendered with different variables", () => {
         let deferred2: Deferred<string>;
         beforeEach(() => {
           deferred2 = new Deferred<string>();
@@ -562,7 +562,7 @@ describe("useQuery", () => {
       });
     });
 
-    describe("is called with skip set to true in React.StrictMode", () => {
+    describe("the hook is rendered with skip set to true in React.StrictMode", () => {
       let renderHookResult: RenderHookResult<
         QueryResult<QueryResponse, QueryVariables>,
         QueryOptionsWithVariables<QueryResponse, QueryVariables>
@@ -583,7 +583,7 @@ describe("useQuery", () => {
           }
         );
       });
-      describe("is called again with skip not set", () => {
+      describe("the hook is rerendered with skip not set", () => {
         beforeEach(() => {
           renderHookResult.rerender({
             variables: { optionA: "run2-A", optionB: "run2-B" },

--- a/use-query.test.ts
+++ b/use-query.test.ts
@@ -395,54 +395,6 @@ describe("when useQuery", () => {
         });
       });
     });
-  });
-
-  describe("is given an asyncronous query without variables", () => {
-    let deferred: Deferred<string>;
-    const mockQuery = jest.fn<Promise<string>, never>();
-    afterEach(() => {
-      mockQuery.mockReset();
-    });
-
-    beforeEach(() => {
-      deferred = new Deferred<string>();
-      mockQuery.mockReturnValue(deferred.promise);
-    });
-
-    describe("the hook is rendered without variables", () => {
-      let renderHookResult: RenderHookResult<
-        QueryResult<string, never>,
-        QueryOptions<string>
-      >;
-      beforeEach(() => {
-        renderHookResult = renderHook<
-          QueryResult<string, never>,
-          QueryOptions<string>
-        >(() => useQuery<string>(mockQuery));
-      });
-      it("should start with loading set to true", async () => {
-        expect(mockQuery).toHaveBeenCalled();
-        expect(mockQuery).toHaveBeenCalledTimes(1);
-        expect(renderHookResult.result.current.error).toBe(null);
-        expect(renderHookResult.result.current.loading).toBe(true);
-        expect(renderHookResult.result.current.data).toBe(null);
-      });
-    });
-  });
-
-  describe("when an asyncronous query with variables", () => {
-    type QueryVariables = { optionA: string; optionB: string };
-    type QueryResponse = string;
-    let deferred: Deferred<QueryResponse>;
-    const mockQuery = jest.fn<Promise<QueryResponse>, [QueryVariables]>();
-    afterEach(() => {
-      mockQuery.mockReset();
-    });
-
-    beforeEach(() => {
-      deferred = new Deferred<QueryResponse>();
-      mockQuery.mockReturnValue(deferred.promise);
-    });
 
     describe("the hook is rendered in React.StrictMode", () => {
       let renderHookResult: RenderHookResult<
@@ -602,6 +554,39 @@ describe("when useQuery", () => {
             expect(renderHookResult.result.current.data).toBe("resolved");
           });
         });
+      });
+    });
+  });
+
+  describe("is given an asyncronous query without variables", () => {
+    let deferred: Deferred<string>;
+    const mockQuery = jest.fn<Promise<string>, never>();
+    afterEach(() => {
+      mockQuery.mockReset();
+    });
+
+    beforeEach(() => {
+      deferred = new Deferred<string>();
+      mockQuery.mockReturnValue(deferred.promise);
+    });
+
+    describe("the hook is rendered without variables", () => {
+      let renderHookResult: RenderHookResult<
+        QueryResult<string, never>,
+        QueryOptions<string>
+      >;
+      beforeEach(() => {
+        renderHookResult = renderHook<
+          QueryResult<string, never>,
+          QueryOptions<string>
+        >(() => useQuery<string>(mockQuery));
+      });
+      it("should start with loading set to true", async () => {
+        expect(mockQuery).toHaveBeenCalled();
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        expect(renderHookResult.result.current.error).toBe(null);
+        expect(renderHookResult.result.current.loading).toBe(true);
+        expect(renderHookResult.result.current.data).toBe(null);
       });
     });
   });

--- a/use-query.ts
+++ b/use-query.ts
@@ -101,7 +101,11 @@ function useQuery<TData, TVariables extends Variables>(
             error: error.current,
             data: data.current,
             previousData: previousData.current,
-            refetch: fetch,
+            refetch: (refetchVariables?: Partial<TVariables> | undefined) => {
+              const result = fetch(refetchVariables);
+              forceUpdate((x) => x + 1);
+              return result;
+            },
           };
         })
         .catch((e) => {
@@ -116,7 +120,11 @@ function useQuery<TData, TVariables extends Variables>(
             error: e,
             data: data.current,
             previousData: previousData.current,
-            refetch: fetch,
+            refetch: (refetchVariables?: Partial<TVariables> | undefined) => {
+              const result = fetch(refetchVariables);
+              forceUpdate((x) => x + 1);
+              return result;
+            },
           };
         });
     },


### PR DESCRIPTION
Some housekeeping:

- Test naming consistency
- Merge duplicate describe blocks in tests

Followed by:

- Add tests for refetch from a refetch (fixed #52)

Which resulted in finding and fixing:
- Refetch from a refetch doesn't trigger rerender (fixed #51)